### PR TITLE
testing and implementation of 記事一覧取得エンドポイント

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -54,6 +54,10 @@ Router::scope(
     }
 );
 
+Router::prefix('api', function (RouteBuilder $routes) {
+    $routes->fallbacks(DashedRoute::class);
+});
+
 Router::scope('/', function (RouteBuilder $routes) {
     // Register scoped middleware for in scopes.
     $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([

--- a/src/Controller/Api/ArticlesController.php
+++ b/src/Controller/Api/ArticlesController.php
@@ -12,4 +12,29 @@ use App\Model\Table\ArticlesTable;
  */
 class ArticlesController extends AppController
 {
+    /**
+     * @throws \Exception
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('RequestHandler');
+    }
+
+    /**
+     * 記事一覧
+     *
+     * @return void
+     */
+    public function index()
+    {
+        $articles = [];
+        $this->set([
+            '_serialize' => ['articles'],
+            'articles' => $articles,
+        ]);
+    }
 }

--- a/src/Controller/Api/ArticlesController.php
+++ b/src/Controller/Api/ArticlesController.php
@@ -31,7 +31,18 @@ class ArticlesController extends AppController
      */
     public function index()
     {
-        $articles = [];
+        // TODO: 記事一覧をデータベースから取得する
+        $articles = [
+            [
+                'user_id' => 1,
+                'title' => 'First Article',
+                'slug' => 'first',
+                'body' => 'First Article Body',
+                'published' => 1,
+                'created' => '2018-01-07 15:47:01',
+                'modified' => '2018-01-07 15:47:02',
+            ],
+        ];
         $this->set([
             '_serialize' => ['articles'],
             'articles' => $articles,

--- a/src/Controller/Api/ArticlesController.php
+++ b/src/Controller/Api/ArticlesController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Controller\AppController;
+use App\Model\Table\ArticlesTable;
+
+/**
+ * Class ArticlesController
+ * @package App\Controller\Api
+ * @property ArticlesTable Articles
+ */
+class ArticlesController extends AppController
+{
+}

--- a/src/Controller/Api/ArticlesController.php
+++ b/src/Controller/Api/ArticlesController.php
@@ -31,7 +31,6 @@ class ArticlesController extends AppController
      */
     public function index()
     {
-        // TODO: 記事一覧をデータベースから取得する
         $articles = $this->Articles->find('all');
         $this->set([
             '_serialize' => ['articles'],

--- a/src/Controller/Api/ArticlesController.php
+++ b/src/Controller/Api/ArticlesController.php
@@ -32,17 +32,7 @@ class ArticlesController extends AppController
     public function index()
     {
         // TODO: 記事一覧をデータベースから取得する
-        $articles = [
-            [
-                'user_id' => 1,
-                'title' => 'First Article',
-                'slug' => 'first',
-                'body' => 'First Article Body',
-                'published' => 1,
-                'created' => '2018-01-07 15:47:01',
-                'modified' => '2018-01-07 15:47:02',
-            ],
-        ];
+        $articles = $this->Articles->find('all');
         $this->set([
             '_serialize' => ['articles'],
             'articles' => $articles,

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -30,7 +30,13 @@ class ArticlesControllerTest extends TestCase
      */
     public function 記事一覧取得にて成功レスポンスが返却される()
     {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json'
+            ],
+        ]);
         $this->get('/api/articles/index');
+
         $this->assertResponseOk();
     }
 }

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Test\TestCase\Controller\Api;
+
+use App\Controller\Api\ArticlesController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Controller\Api\ArticlesController Test Case
+ */
+class ArticlesControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'app.Articles'
+    ];
+
+    /**
+     * @test
+     *
+     * @throws \PHPUnit\Exception
+     *
+     * @return void
+     */
+    public function 記事一覧取得にて成功レスポンスが返却される()
+    {
+        $this->get('/api/articles/index');
+        $this->assertResponseOk();
+    }
+}

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -40,4 +40,37 @@ class ArticlesControllerTest extends TestCase
         $this->assertResponseOk();
         $this->assertSame('application/json', $this->_response->getType());
     }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws \PHPUnit\Exception
+     */
+    public function 記事一覧取得にて一覧情報が返却される()
+    {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
+        $this->get('/api/articles/index');
+
+        $expected = [
+            'articles' => [
+                [
+                    'user_id' => 1,
+                    'title' => 'First Article',
+                    'slug' => 'first',
+                    'body' => 'First Article Body',
+                    'published' => 1,
+                    'created' => '2018-01-07 15:47:01',
+                    'modified' => '2018-01-07 15:47:02',
+                ],
+            ],
+        ];
+        $expected = json_encode($expected, JSON_PRETTY_PRINT);
+        $this->assertSame($expected, (string)$this->_response->getBody());
+    }
 }

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -38,5 +38,6 @@ class ArticlesControllerTest extends TestCase
         $this->get('/api/articles/index');
 
         $this->assertResponseOk();
+        $this->assertSame('application/json', $this->_response->getType());
     }
 }

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -2,6 +2,7 @@
 namespace App\Test\TestCase\Controller\Api;
 
 use App\Controller\Api\ArticlesController;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -70,6 +71,32 @@ class ArticlesControllerTest extends TestCase
                     'modified' => '2018-01-07T15:47:02+00:00',
                 ],
             ],
+        ];
+        $expected = json_encode($expected, JSON_PRETTY_PRINT);
+        $this->assertSame($expected, (string)$this->_response->getBody());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws \PHPUnit\Exception
+     */
+    public function 記事一覧取得にてレコードがない場合、0件の情報が返却される()
+    {
+        $Articles = TableRegistry::getTableLocator()->get('Articles');
+        $Articles->deleteAll([]);
+
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
+        $this->get('/api/articles/index');
+
+        $expected = [
+            "articles" => [],
         ];
         $expected = json_encode($expected, JSON_PRETTY_PRINT);
         $this->assertSame($expected, (string)$this->_response->getBody());

--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -60,13 +60,14 @@ class ArticlesControllerTest extends TestCase
         $expected = [
             'articles' => [
                 [
+                    'id' => 1,
                     'user_id' => 1,
                     'title' => 'First Article',
                     'slug' => 'first',
                     'body' => 'First Article Body',
                     'published' => 1,
-                    'created' => '2018-01-07 15:47:01',
-                    'modified' => '2018-01-07 15:47:02',
+                    'created' => '2018-01-07T15:47:01+00:00',
+                    'modified' => '2018-01-07T15:47:02+00:00',
                 ],
             ],
         ];

--- a/tests/TestCase/Model/Table/ArticlesTableTest.php
+++ b/tests/TestCase/Model/Table/ArticlesTableTest.php
@@ -23,7 +23,7 @@ class ArticlesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Articles = TableRegistry::get('Articles');
+        $this->Articles = TableRegistry::getTableLocator()->get('Articles');
     }
 
     /**

--- a/tests/TestCase/Routing/RoutingTest.php
+++ b/tests/TestCase/Routing/RoutingTest.php
@@ -24,7 +24,6 @@ class RoutingTest extends TestCase
     public function Route正引き(string $url, array $expected, array $expected_pass)
     {
         $actual = Router::parseRequest(new ServerRequest($url));
-        $this->assertSame($expected['prefix'], $actual['prefix']);
         $this->assertSame($expected['controller'], $actual['controller']);
         $this->assertSame($expected['action'], $actual['action']);
         $this->assertSame($expected_pass, $actual['pass']);

--- a/tests/TestCase/Routing/RoutingTest.php
+++ b/tests/TestCase/Routing/RoutingTest.php
@@ -24,6 +24,7 @@ class RoutingTest extends TestCase
     public function Route正引き(string $url, array $expected, array $expected_pass)
     {
         $actual = Router::parseRequest(new ServerRequest($url));
+        $this->assertSame($expected['prefix'], $actual['prefix']);
         $this->assertSame($expected['controller'], $actual['controller']);
         $this->assertSame($expected['action'], $actual['action']);
         $this->assertSame($expected_pass, $actual['pass']);
@@ -84,6 +85,7 @@ class RoutingTest extends TestCase
             '/api/articles' => [
                 'url' => '/api/articles',
                 'expected' => [
+                    'prefix' => 'api',
                     'controller' => 'Articles',
                     'action' => 'index'
                 ],

--- a/tests/TestCase/Routing/RoutingTest.php
+++ b/tests/TestCase/Routing/RoutingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Test\TestCase\Routing;
+
+use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+
+class RoutingTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * 正引き（'/url' => 配列）
+     *
+     * @dataProvider dataRouting
+     *
+     * @param string $url
+     * @param array $expected
+     * @param array $expected_pass
+     *
+     * @return void
+     */
+    public function Route正引き(string $url, array $expected, array $expected_pass)
+    {
+        $actual = Router::parseRequest(new ServerRequest($url));
+        $this->assertSame($expected['controller'], $actual['controller']);
+        $this->assertSame($expected['action'], $actual['action']);
+        $this->assertSame($expected_pass, $actual['pass']);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider dataRouting
+     *
+     * @param string $expected
+     * @param array $parseArray
+     *
+     * @return void
+     */
+    public function Route逆引き(string $expected, array $parseArray)
+    {
+        $this->assertSame($expected, Router::url($parseArray));
+    }
+
+
+    public function dataRouting(): array
+    {
+        return [
+            '/' => [
+                'url' => '/',
+                'expected' => [
+                    'controller' => 'Pages',
+                    'action' => 'display',
+                    'home'
+                ],
+                'expected_pass' => ['home'],
+            ],
+            '/articles' => [
+                'url' => '/articles',
+                'expected' => [
+                    'controller' => 'Articles',
+                    'action' => 'index',
+                ],
+                'expected_pass' => [],
+            ],
+            '/articles/tagged' => [
+                'url' => '/articles/tagged',
+                'expected' => [
+                    'controller' => 'Articles',
+                    'action' => 'tags',
+                ],
+                'expected_pass' => [],
+            ],
+            '/articles/tagged/funny/cat/gifs' => [
+                'url' => '/articles/tagged/funny/cat/gifs',
+                'expected' => [
+                    'controller' => 'Articles',
+                    'action' => 'tags',
+                    'funny', 'cat', 'gifs',
+                ],
+                'expected_pass' => ['funny', 'cat', 'gifs'],
+            ],
+        ];
+    }
+}

--- a/tests/TestCase/Routing/RoutingTest.php
+++ b/tests/TestCase/Routing/RoutingTest.php
@@ -44,7 +44,6 @@ class RoutingTest extends TestCase
         $this->assertSame($expected, Router::url($parseArray));
     }
 
-
     public function dataRouting(): array
     {
         return [
@@ -81,6 +80,14 @@ class RoutingTest extends TestCase
                     'funny', 'cat', 'gifs',
                 ],
                 'expected_pass' => ['funny', 'cat', 'gifs'],
+            ],
+            '/api/articles' => [
+                'url' => '/api/articles',
+                'expected' => [
+                    'controller' => 'Articles',
+                    'action' => 'index'
+                ],
+                'expected_pass' => [],
             ],
         ];
     }

--- a/tests/TestCase/Routing/RoutingTest.php
+++ b/tests/TestCase/Routing/RoutingTest.php
@@ -82,15 +82,37 @@ class RoutingTest extends TestCase
                 ],
                 'expected_pass' => ['funny', 'cat', 'gifs'],
             ],
-            '/api/articles' => [
-                'url' => '/api/articles',
-                'expected' => [
-                    'prefix' => 'api',
-                    'controller' => 'Articles',
-                    'action' => 'index'
-                ],
-                'expected_pass' => [],
-            ],
         ];
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws \PHPUnit\Exception
+     */
+    public function apiプレフィックスRoute正引き()
+    {
+        $actual = Router::parseRequest(new ServerRequest('/api/articles'));
+        $this->assertSame('api', $actual['prefix']);
+        $this->assertSame('Articles', $actual['controller']);
+        $this->assertSame('index', $actual['action']);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws \PHPUnit\Exception
+     */
+    public function apiプレフィックスRoute逆引き()
+    {
+        $this->assertSame('/api/articles', Router::url([
+            'prefix' => 'api',
+            'controller' => 'Articles',
+            'action' => 'index',
+        ]));
     }
 }


### PR DESCRIPTION
# Progress
- after commit: test 記事一覧取得にて成功レスポンスが返却される

```
Possibly related to Cake\Routing\Exception\MissingControllerException: "Controller class Api could not be found." 

Failed asserting that 404 is between 200 and 204.
```

- after commit: test /api/articlesのルーティングに成功する and implement routing

```
Possibly related to Cake\Routing\Exception\MissingControllerException: "Controller class Articles could not be found." 

Failed asserting that 404 is between 200 and 204.
```

- after commit: create Controller/Api/ArticlesController class

```
Possibly related to Cake\Controller\Exception\MissingActionException: "Action ArticlesController::index() could not be found, or is not accessible." 

Failed asserting that 404 is between 200 and 204.
```

- after commit: test passed 記事一覧取得にて成功レスポンスが返却される

```
OK (1 test, 2 assertions)
```

- after commit: test failed 記事一覧取得にて一覧情報が返却される

```
Failed asserting that two strings are identical.
```

refs

- https://book.cakephp.org/3.0/ja/development/routing.html#prefix-routing
- https://book.cakephp.org/3.0/ja/views/json-and-xml-views.html