### PR TITLE
test failed 記事詳細取得にて成功レスポンスが返却される

### DIFF
--- a/tests/TestCase/Controller/Api/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/Api/ArticlesControllerTest.php
@@ -101,4 +101,23 @@ class ArticlesControllerTest extends TestCase
         $expected = json_encode($expected, JSON_PRETTY_PRINT);
         $this->assertSame($expected, (string)$this->_response->getBody());
     }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws \PHPUnit\Exception
+     */
+    public function 記事詳細取得にて成功レスポンスが返却される()
+    {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
+        $this->get('/api/articles/view/first');
+
+        $this->assertResponseSuccess();
+    }
 }


### PR DESCRIPTION
# Progress

- after commit: test failed 記事詳細取得にて成功レスポンスが返却される

```
Possibly related to Cake\Controller\Exception\MissingActionException: "Action ArticlesController::view() could not be found, or is not accessible." 

Failed asserting that 404 is between 200 and 308.
```
